### PR TITLE
Dampen issues caused by scaling when not necessary

### DIFF
--- a/lib/desired.js
+++ b/lib/desired.js
@@ -26,7 +26,15 @@ module.exports = (params, cb) => {
         services: [params.service]
     }, (err, data) => {
         if(err) return cb(err);
-        const currentDesired = R.prop('desiredCount' ,data.services[0]);
+        const currentDesired = R.prop('desiredCount', data.services[0]);
+        const currentRunning = R.prop('runningCount', data.services[0]);
+        //We should not attempt to scale if we are not at the desired state already
+        if(currentRunning !== currentDesired) {
+            return cb(null, {
+                current: currentDesired,
+                required: currentDesired
+            });
+        }
         elb.describeTargetGroups({
             TargetGroupArns: [data.services[0].loadBalancers[0].targetGroupArn],
             PageSize: 1


### PR DESCRIPTION
This could cause flip-flopping when the service is too slow to add new
tasks or remove old tasks